### PR TITLE
Added `beforeSave` as a constructor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,12 @@ var notes = restifyMongoose(Note, {filter: filterUser});
 * Added coverage script to package.json
 * The insert and update operations now use aync.waterfall
 * The server test helper has an optional parameter which will set or not set default routes 
- 
-### 0.2.1
 
+### 0.2.1
 * Updates to restify 2.8.x
 * Updates to async 0.9.x
 * Improved the error message for mongoose validation errors
 * Code cleanup
+
+### 0.2.2
+* The `beforeSave` option can now be included in the options passed to the `restifyMongoose` constructor.

--- a/index.js
+++ b/index.js
@@ -172,6 +172,7 @@ Resource.prototype.insert = function (options) {
   var self = this;
 
   options = options || {};
+  options.beforeSave = options.beforeSave || this.options.beforeSave;
 
   return function(req, res, next) {
     var model = new self.Model(req.body);
@@ -189,6 +190,7 @@ Resource.prototype.update = function (options) {
   var self = this;
 
   options = options || {};
+  options.beforeSave = options.beforeSave || this.options.beforeSave;
 
   return function (req, res, next) {
     var query = self.Model.findOne({ _id: req.params.id});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-mongoose",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Expose mongoose models as REST resources",
   "author": "christoph.walcher@gmail.com",
   "contributors": [


### PR DESCRIPTION
I started to use all of the new features and discovered that by not having `beforeSave` as a construction option, like `filter`, I would have to write out all of the paths again, which is what I was trying to avoid in the first place. So I made a very simple update.
