### PR TITLE
Support base urls with paths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ var applyPageLinks = function (req, res, page, pageSize, baseUrl) {
     var path = url.parse(req.url, true);
     path.query.p = page;
     delete path.search; // required for url.format to re-generate querystring
-    var href = url.resolve(baseUrl, url.format(path));
+    var href = baseUrl + url.format(path);
     return util.format('<%s>; rel="%s"', href, rel);
   }
 

--- a/test/restify-mongoose.js
+++ b/test/restify-mongoose.js
@@ -251,6 +251,17 @@ describe('restify-mongoose', function () {
           })
           .end(done);
       });
+
+      it('should include base url paths in link header urls', function (done) {
+        request(server({ pageSize: 2, baseUrl: 'http://example.com/v1' }))
+          .get('/notes?p=0')
+          .expect(200)
+          .expect(function(res) {
+            res.headers.should.have.property("link");
+            res.headers.link.should.match(new RegExp('<http://example.com/v1/notes\\?p=0>; rel="first"'));
+          })
+          .end(done);
+      });
     });
   });
 


### PR DESCRIPTION
I prematurely used a url.resolve not realizing it would strip away any paths included in the base url. That would prevent having a proxy in front of your API and serving out the API under base routes like `/api` or `/v1`.
