### PR TITLE
Package upgrade. Last link. Total count. PageSize. Bug fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,13 @@ users.serve('/users', restifyServer);
 
 ### 0.2.2
 * The `beforeSave` option can now be included in the options passed to the `restifyMongoose` constructor.
+
+### 0.3.0
+* Added total count of resources for `query` by adding X-Total-Count header`
+* Updated to async 1.2.1
+* Updated to mongoose 4.0.6
+* Updated to restify 3.0.3
+* Updated to mocha 2.2.5
+* Updated to should 7.0.1
+* Updated to supertest 1.0.1
+* Updated to istanbul 0.3.16

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ users.serve('/users', restifyServer);
 * The `beforeSave` option can now be included in the options passed to the `restifyMongoose` constructor.
 
 ### 0.3.0
-* Added total count of resources for `query` by adding X-Total-Count header`
+* Added total count of resources for `query` by adding `X-Total-Count header`
 * Added `last` relation in Link Header for showing URL to last page with results
 * Updated to async 1.2.1
 * Updated to mongoose 4.0.6

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ var options = {
 var notes = restifyMongoose(Note, options);
 ```
 
-or as query string parameter `pageSize`
+or as query string parameter `pageSize` (which will have the presedence)
 
     http://localhost:3000/notes?pageSize=2
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To filter a notes resource by title to match term "first" append the __q__ query
 
 ## Paginate
 Requests that return multiple items in `query` will be paginated to 100 items by default. You can set the `pageSize`
-by adding it to the options.
+(number min=1, max=100) by adding it to the options.
 
 ```javascript
 var options = {
@@ -123,6 +123,11 @@ var options = {
 
 var notes = restifyMongoose(Note, options);
 ```
+
+or as query string parameter `pageSize`
+
+    http://localhost:3000/notes?pageSize=2
+
 
 You can specify further pages with the __p__ parameter and a page number.
 
@@ -278,6 +283,7 @@ users.serve('/users', restifyServer);
 ### 0.3.0
 * Added total count of resources for `query` by adding `X-Total-Count header`
 * Added `last` relation in Link Header for showing URL to last page with results
+* Added `pageSize` as query string parameter in order to set page size for pagination in the URL itself
 * Updated to async 1.2.1
 * Updated to mongoose 4.0.6
 * Updated to restify 3.0.3

--- a/README.md
+++ b/README.md
@@ -112,6 +112,51 @@ To filter a notes resource by title to match term "first" append the __q__ query
 
     http://localhost:3000/notes?q={"title":"first"}
 
+## Paginate
+Requests that return multiple items in `query` will be paginated to 100 items by default. You can set the `pageSize`
+by adding it to the options.
+
+```javascript
+var options = {
+	pageSize: 2
+};
+
+var notes = restifyMongoose(Note, options);
+```
+
+You can specify further pages with the __p__ parameter and a page number.
+
+    http://localhost:3000/notes?p=1
+
+### Link Header
+The pagination info is included in [the Link header](http://tools.ietf.org/html/rfc5988). It is important to follow
+these Link header values instead of constructing your own URLs.
+
+    link:
+    <http://example.com/notes?p=0>; rel="first",
+    <http://example.com/notes?p=1>; rel="prev",
+    <http://example.com/notes/?p=3>; rel="next"
+
+_Linebreak is included for readability._
+
+You can set the `baseUrl` by adding it to the options.
+
+```javascript
+var options = {
+	baseUrl: 'http://example.com'
+};
+```
+
+The possible `rel` values are:
+
+* ***next*** - Shows the URL of the immediate next page of results.
+* ***last*** - NOT IMPLEMENTED YET! Shows the URL of the last page of results.
+* ***first*** - Shows the URL of the first page of results.
+* ***prev*** - Shows the URL of the immediate previous page of results.
+
+### Total Count Header
+The total number of results/resources returned in `query` is sent in the `X-Total-Count Header` and is not affected by
+pagination (setting `pageSize` and __p__ parameter). It does take in account filter and query parameter ( __q__ ).
 
 ## Sort
 Sort parameters are passed by query string parameter __sort__.
@@ -130,13 +175,13 @@ Select fields are passed directly to [mongoose select query function](http://mon
 To select only date the field of a notes resource append the __select__ query parameter to the URL:
 
     http://localhost:3000/notes?select=date
-    
+
 ## Filter
 Results can be filtered with a function, which is set in the options object of the constructor or on the `query` and `detail` function.
 
 The function takes two parameters: the request object and the response object. The return value of the function is a query that is passed directly to the [mongoose where query function](http://mongoosejs.com/docs/api.html#query_Query-where).
 
-For instance, you can use a filter to display only results for a particular user: 
+For instance, you can use a filter to display only results for a particular user:
 
 ```javascript
 var filterUser = function(req, res) {
@@ -219,7 +264,7 @@ users.serve('/users', restifyServer);
 * Added `beforeSave` functionality to the **insert** and **update** operations.
 * Added coverage script to package.json
 * The insert and update operations now use aync.waterfall
-* The server test helper has an optional parameter which will set or not set default routes 
+* The server test helper has an optional parameter which will set or not set default routes
 
 ### 0.2.1
 * Updates to restify 2.8.x

--- a/README.md
+++ b/README.md
@@ -284,10 +284,13 @@ users.serve('/users', restifyServer);
 * Added total count of resources for `query` by adding `X-Total-Count header`
 * Added `last` relation in Link Header for showing URL to last page with results
 * Added `pageSize` as query string parameter in order to set page size for pagination in the URL itself
-* Updated to async 1.2.1
-* Updated to mongoose 4.0.6
-* Updated to restify 3.0.3
-* Updated to mocha 2.2.5
-* Updated to should 7.0.1
-* Updated to supertest 1.0.1
-* Updated to istanbul 0.3.16
+* Fixed bug when returning Location URL for `PATCH`, model._id was duplicated
+* Changed status code to `201 CREATED` for successful `POST` requests
+* Updated runtime and dev dependencies to latest versions
+    * Updated to async 1.2.1
+    * Updated to mongoose 4.0.6
+    * Updated to restify 3.0.3
+    * Updated to mocha 2.2.5
+    * Updated to should 7.0.1
+    * Updated to supertest 1.0.1
+    * Updated to istanbul 0.3.16

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ these Link header values instead of constructing your own URLs.
     link:
     <http://example.com/notes?p=0>; rel="first",
     <http://example.com/notes?p=1>; rel="prev",
-    <http://example.com/notes/?p=3>; rel="next"
+    <http://example.com/notes/?p=3>; rel="next",
+    <http://example.com/notes/?p=4>; rel="last"
 
 _Linebreak is included for readability._
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ var options = {
 The possible `rel` values are:
 
 * ***next*** - Shows the URL of the immediate next page of results.
-* ***last*** - NOT IMPLEMENTED YET! Shows the URL of the last page of results.
+* ***last*** - Shows the URL of the last page of results.
 * ***first*** - Shows the URL of the first page of results.
 * ***prev*** - Shows the URL of the immediate previous page of results.
 
@@ -277,6 +277,7 @@ users.serve('/users', restifyServer);
 
 ### 0.3.0
 * Added total count of resources for `query` by adding X-Total-Count header`
+* Added `last` relation in Link Header for showing URL to last page with results
 * Updated to async 1.2.1
 * Updated to mongoose 4.0.6
 * Updated to restify 3.0.3

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var emitEvent = function (self, event) {
     if (cb) {
       cb(undefined, model);
     }
-  }
+  };
 };
 
 var sendData = function (res, format, modelName, status) {
@@ -39,7 +39,7 @@ var sendData = function (res, format, modelName, status) {
       res.send(status, model);
     }
     cb(undefined, model);
-  }
+  };
 };
 
 var execQueryWithTotCount = function (query, countQuery) {
@@ -61,14 +61,14 @@ var execQueryWithTotCount = function (query, countQuery) {
         }
       });
 
-  }
-}
+  };
+};
 
 var execQuery = function (query) {
   return function (cb) {
     query.exec(cb);
-  }
-}
+  };
+};
 
 var execBeforeSave = function (req, model, beforeSave) {
   if (!beforeSave) {
@@ -84,10 +84,12 @@ var execBeforeSave = function (req, model, beforeSave) {
 var execSave = function (model) {
   return function (cb) {
     model.save(function (err, model) {
-      if (err)
+      if (err) {
         return cb(restifyError(err));
-      else
+      }
+      else {
         cb(null, model);
+      }
     });
   };
 };
@@ -123,7 +125,7 @@ var buildProjections = function (req, projection) {
     };
 
     async.map(models, iterator, cb);
-  }
+  };
 };
 
 var buildProjection = function (req, projection) {
@@ -133,7 +135,7 @@ var buildProjection = function (req, projection) {
     }
 
     projection(req, model, cb);
-  }
+  };
 };
 
 var applyPageLinks = function (req, res, page, pageSize, baseUrl) {
@@ -173,7 +175,7 @@ var applyPageLinks = function (req, res, page, pageSize, baseUrl) {
 
     cb(null, models, totalCount);
   };
-}
+};
 
 var applyTotalCount = function (res) {
   return function applyTotalCountInner(models, totalCount, cb) {
@@ -181,7 +183,7 @@ var applyTotalCount = function (res) {
 
     cb(null, models);
   };
-}
+};
 
 var Resource = function (Model, options) {
   EventEmitter.call(this);
@@ -243,8 +245,7 @@ Resource.prototype.query = function (options) {
     var page = Number(req.query.p) >= 0 ? Number(req.query.p) : 0;
 
     // pageSize parameter in queryString overrides one in the code. Must be number between [1-100]
-    options.pageSize = Number(req.query.pageSize) > 0 && Number(req.query.pageSize) <= 100
-      ? Number(req.query.pageSize) : options.pageSize;
+    options.pageSize = Number(req.query.pageSize) > 0 && Number(req.query.pageSize) <= 100 ? Number(req.query.pageSize) : options.pageSize;
 
     query.skip(options.pageSize * page);
     query.limit(options.pageSize + 1);

--- a/index.js
+++ b/index.js
@@ -28,15 +28,15 @@ var emitEvent = function (self, event) {
   }
 };
 
-var sendData = function (res, format, modelName) {
+var sendData = function (res, format, modelName, status) {
   return function (model, cb) {
     if (format === 'json-api') {
       var responseObj = {};
       responseObj[modelName] = model;
-      res.json(responseObj);
+      res.json(status, responseObj);
     }
     else {
-      res.send(model);
+      res.send(status, model);
     }
     cb(undefined, model);
   }
@@ -302,7 +302,7 @@ Resource.prototype.insert = function (options) {
       execSave(model),
       setLocationHeader(req, res, true, options.baseUrl),
       emitEvent(self, 'insert'),
-      sendData(res, options.outputFormat, options.modelName)
+      sendData(res, options.outputFormat, options.modelName, 201)
     ], next);
   };
 };

--- a/index.js
+++ b/index.js
@@ -245,14 +245,14 @@ Resource.prototype.query = function (options) {
     var page = Number(req.query.p) >= 0 ? Number(req.query.p) : 0;
 
     // pageSize parameter in queryString overrides one in the code. Must be number between [1-100]
-    options.pageSize = Number(req.query.pageSize) > 0 && Number(req.query.pageSize) <= 100 ? Number(req.query.pageSize) : options.pageSize;
+    var pageSize = Number(req.query.pageSize) > 0 && Number(req.query.pageSize) <= 100 ? Number(req.query.pageSize) : options.pageSize;
 
-    query.skip(options.pageSize * page);
-    query.limit(options.pageSize + 1);
+    query.skip(pageSize * page);
+    query.limit(pageSize + 1);
 
     async.waterfall([
       execQueryWithTotCount(query, countQuery),
-      applyPageLinks(req, res, page, options.pageSize, options.baseUrl),
+      applyPageLinks(req, res, page, pageSize, options.baseUrl),
       applyTotalCount(res),
       buildProjections(req, options.projection),
       emitEvent(self, 'query'),

--- a/index.js
+++ b/index.js
@@ -129,17 +129,27 @@ var applyPageLinks = function (req, res, page, pageSize, baseUrl) {
   }
 
   return function applyPageLinksInner(models, totalCount, cb) {
+    // rel: first
     var link = makeLink(0, 'first');
 
+    // rel: prev
     if (page > 0) {
       link += ', ' + makeLink(page - 1, 'prev');
     }
 
+    // rel: next
     var moreResults = models.length > pageSize;
     if (moreResults) {
       models.pop();
 
       link += ', ' + makeLink(page + 1, 'next');
+    }
+
+    // rel: last
+    var lastPage = 0;
+    if (pageSize > 0) {
+      lastPage = Math.ceil(totalCount / pageSize) - 1;
+      link += ', ' + makeLink(lastPage, 'last');
     }
 
     res.setHeader('link', link);

--- a/index.js
+++ b/index.js
@@ -224,6 +224,11 @@ Resource.prototype.query = function (options) {
     }
 
     var page = Number(req.query.p) >= 0 ? Number(req.query.p) : 0;
+
+    // pageSize parameter in queryString overrides one in the code. Must be number between [1-100]
+    options.pageSize = Number(req.query.pageSize) > 0 && Number(req.query.pageSize) <= 100
+      ? Number(req.query.pageSize) : options.pageSize;
+
     query.skip(options.pageSize * page);
     query.limit(options.pageSize + 1);
 

--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
   ],
   "license": "BSD-2-Clause",
   "dependencies": {
-    "async": "~0.9.0",
-    "mongoose": "~3.8.24",
-    "restify": "~2.8.5"
+    "async": "~1.2.1",
+    "mongoose": "~4.0.6",
+    "restify": "~3.0.3"
   },
   "devDependencies": {
-    "mocha": "~2.2.0",
-    "should": "~5.1.0",
-    "supertest": "~0.15.0",
-    "istanbul": "^0.3.7"
+    "mocha": "~2.2.5",
+    "should": "~7.0.1",
+    "supertest": "~1.0.1",
+    "istanbul": "^0.3.16"
   },
   "bugs": "https://github.com/saintedlama/restify-mongoose/issues",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV=test mocha -R spec test/",
-    "cover": "NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcov -- -R spec"
+    "cover": "NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcov -- -R spec",
+    "lint": "jshint **.js"
   },
   "keywords": [
     "restify",
@@ -33,10 +34,11 @@
     "restify": "~3.0.3"
   },
   "devDependencies": {
+    "istanbul": "^0.3.16",
+    "jshint": "^2.8.0",
     "mocha": "~2.2.5",
     "should": "~7.0.1",
-    "supertest": "~1.0.1",
-    "istanbul": "^0.3.16"
+    "supertest": "~1.0.1"
   },
   "bugs": "https://github.com/saintedlama/restify-mongoose/issues",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "BSD-2-Clause",
   "dependencies": {
-    "async": "~1.2.1",
+    "async": "~1.0.0",
     "mongoose": "~4.0.6",
     "restify": "~3.0.3"
   },

--- a/test/restify-mongoose.js
+++ b/test/restify-mongoose.js
@@ -156,6 +156,56 @@ describe('restify-mongoose', function () {
         .end(done);
     });
 
+    it('should use pageSize sent as query string if positive number', function (done) {
+      request(server())
+        .get('/notes?pageSize=3')
+        .expect(200)
+        .expect(function (res) {
+          res.body.should.have.lengthOf(3);
+        })
+        .end(done);
+    });
+
+    it('should not use pageSize sent as query string if greater then 100', function (done) {
+      request(server({pageSize: 1}))
+        .get('/notes?pageSize=101')
+        .expect(200)
+        .expect(function (res) {
+          res.body.should.have.lengthOf(1);
+        })
+        .end(done);
+    });
+
+    it('should not use pageSize sent as query string if lower then 0', function (done) {
+      request(server({pageSize: 2}))
+        .get('/notes?pageSize=-1')
+        .expect(200)
+        .expect(function (res) {
+          res.body.should.have.lengthOf(2);
+        })
+        .end(done);
+    });
+
+    it('should not use pageSize sent as query string if not a number', function (done) {
+      request(server({pageSize: 2}))
+        .get('/notes?pageSize=abcd')
+        .expect(200)
+        .expect(function (res) {
+          res.body.should.have.lengthOf(2);
+        })
+        .end(done);
+    });
+
+    it('should not use pageSize sent as query string if it is 0', function (done) {
+      request(server({pageSize: 2}))
+        .get('/notes?pageSize=0')
+        .expect(200)
+        .expect(function (res) {
+          res.body.should.have.lengthOf(2);
+        })
+        .end(done);
+    });
+
     function assertFirstPage(suffix) {
       return function (done) {
         request(server({pageSize: 2, baseUrl: 'http://example.com'}))

--- a/test/restify-mongoose.js
+++ b/test/restify-mongoose.js
@@ -156,7 +156,7 @@ describe('restify-mongoose', function () {
         .end(done);
     });
 
-    it('should use pageSize sent as query string if positive number', function (done) {
+    it('should use req.query.pageSize if positive number', function (done) {
       request(server())
         .get('/notes?pageSize=3')
         .expect(200)
@@ -166,7 +166,29 @@ describe('restify-mongoose', function () {
         .end(done);
     });
 
-    it('should not use pageSize sent as query string if greater then 100', function (done) {
+    it('should override with req.query.pageSize if options.pageSize set', function (done) {
+      request(server({pageSize: 1}))
+        .get('/notes?pageSize=3')
+        .expect(200)
+        .expect(function (res) {
+          res.body.should.have.lengthOf(3);
+        })
+        .end(done);
+    });
+
+    it('should go back to options.pageSize if req.query.pageSize removed', function (done) {
+      var agent = request(server({pageSize: 1}));
+      agent.get('/notes?pageSize=3').end(function(){
+        agent.get('/notes')
+          .expect(200)
+          .expect(function (res) {
+            res.body.should.have.lengthOf(1);
+          })
+          .end(done);
+      });
+    });
+
+    it('should not use req.query.pageSize if greater then 100', function (done) {
       request(server({pageSize: 1}))
         .get('/notes?pageSize=101')
         .expect(200)
@@ -176,7 +198,7 @@ describe('restify-mongoose', function () {
         .end(done);
     });
 
-    it('should not use pageSize sent as query string if lower then 0', function (done) {
+    it('should not use req.query.pageSize if lower then 0', function (done) {
       request(server({pageSize: 2}))
         .get('/notes?pageSize=-1')
         .expect(200)
@@ -186,7 +208,7 @@ describe('restify-mongoose', function () {
         .end(done);
     });
 
-    it('should not use pageSize sent as query string if not a number', function (done) {
+    it('should not use req.query.pageSize if not a number', function (done) {
       request(server({pageSize: 2}))
         .get('/notes?pageSize=abcd')
         .expect(200)
@@ -196,7 +218,7 @@ describe('restify-mongoose', function () {
         .end(done);
     });
 
-    it('should not use pageSize sent as query string if it is 0', function (done) {
+    it('should not use req.query.pageSize if it is 0', function (done) {
       request(server({pageSize: 2}))
         .get('/notes?pageSize=0')
         .expect(200)

--- a/test/restify-mongoose.js
+++ b/test/restify-mongoose.js
@@ -517,7 +517,7 @@ describe('restify-mongoose', function () {
         .post('/notes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function (res) {
           res.headers.should.have.property("location");
         })
@@ -539,7 +539,7 @@ describe('restify-mongoose', function () {
         .post('/notes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function (res) {
           res.headers.should.have.property("location");
           res.body.content.should.equal(content);
@@ -575,7 +575,7 @@ describe('restify-mongoose', function () {
         .post('/notes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function () {
           eventEmitted.should.be.ok;
           eventArg.should.be.ok;
@@ -588,7 +588,7 @@ describe('restify-mongoose', function () {
         .post('/notes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function (res) {
           res.headers.should.have.property("location");
           res.headers.location.should.be.equal('http://example.com/notes/' + res.body._id);
@@ -601,7 +601,7 @@ describe('restify-mongoose', function () {
         .post('/notes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function (res) {
           res.headers.should.have.property("location");
           res.headers.location.should.be.equal('/notes/' + res.body._id);
@@ -1010,7 +1010,7 @@ describe('restify-mongoose', function () {
         .post('/servenotes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function (res) {
           res.headers.should.have.property("location");
           beforeCalled.should.matchEach(true);
@@ -1038,7 +1038,7 @@ describe('restify-mongoose', function () {
         .post('/servenotes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function (res) {
           res.headers.should.have.property("location");
           res.body.content.should.equal(content);
@@ -1157,7 +1157,7 @@ describe('restify-mongoose', function () {
         .post('/servenotes')
         .send({title: 'Buy a ukulele without middleware', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function (res) {
           res.headers.should.have.property("location");
         })
@@ -1181,7 +1181,7 @@ describe('restify-mongoose', function () {
         .post('/servenotes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function () {
           beforeCalled.should.equal(true);
         })
@@ -1205,9 +1205,28 @@ describe('restify-mongoose', function () {
         .post('/servenotes')
         .send({title: 'Buy a ukulele', date: new Date()})
         .expect('Content-Type', /json/)
-        .expect(200)
+        .expect(201)
         .expect(function () {
           afterCalled.should.equal(true);
+        })
+        .end(done);
+    });
+  });
+
+  describe('output formats', function () {
+    before(mongoTest.prepareDb('mongodb://localhost/restify-mongoose-tests'));
+    after(mongoTest.disconnect());
+
+    it('should return json-api format if defined in options', function (done) {
+      request(server({outputFormat: 'json-api'}))
+        .post('/notes')
+        .send({title: 'Buy a ukulele', date: new Date()})
+        .expect('Content-Type', /json/)
+        .expect(201)
+        .expect(function (res) {
+          res.headers.should.have.property("location");
+          res.body.should.have.property("notes");
+          res.body.notes.title.should.be.equal("Buy a ukulele");
         })
         .end(done);
     });

--- a/test/restify-mongoose.js
+++ b/test/restify-mongoose.js
@@ -318,6 +318,50 @@ describe('restify-mongoose', function () {
           })
           .end(done);
       });
+
+      it('should include last page url in link header if at first page', function (done) {
+        request(server({pageSize: 2, baseUrl: 'http://example.com'}))
+          .get('/notes?p=0')
+          .expect(200)
+          .expect(function (res) {
+            res.headers.should.have.property("link");
+            res.headers.link.should.match(new RegExp('<http://example.com/notes\\?p=2>; rel="last"'));
+          })
+          .end(done);
+      });
+
+      it('should include last page url in link header if not at first page', function (done) {
+        request(server({pageSize: 2, baseUrl: 'http://example.com'}))
+          .get('/notes?p=1')
+          .expect(200)
+          .expect(function (res) {
+            res.headers.should.have.property("link");
+            res.headers.link.should.match(new RegExp('<http://example.com/notes\\?p=2>; rel="last"'));
+          })
+          .end(done);
+      });
+
+      it('should include last page url in link header if at last page', function (done) {
+        request(server({pageSize: 2, baseUrl: 'http://example.com'}))
+          .get('/notes?p=2')
+          .expect(200)
+          .expect(function (res) {
+            res.headers.should.have.property("link");
+            res.headers.link.should.match(new RegExp('<http://example.com/notes\\?p=2>; rel="last"'));
+          })
+          .end(done);
+      });
+
+      it('should include last page url in link header if page size set to 0', function (done) {
+        request(server({pageSize: 0, baseUrl: 'http://example.com'}))
+          .get('/notes?p=2')
+          .expect(200)
+          .expect(function (res) {
+            res.headers.should.have.property("link");
+            res.headers.link.should.match(new RegExp('<http://example.com/notes\\?p=0>; rel="last"'));
+          })
+          .end(done);
+      });
     });
   });
 


### PR DESCRIPTION
* Added total count of resources for `query` by adding `X-Total-Count header`
* Added `last` relation in Link Header for showing URL to last page with results
* Added `pageSize` as query string parameter in order to set page size for pagination in the URL itself
* Fixed bug when returning Location URL for `PATCH`, model._id was duplicated
* Changed status code to `201 CREATED` for successful `POST` requests
* Updated runtime and dev dependencies to latest versions
    * Updated to async 1.2.1
    * Updated to mongoose 4.0.6
    * Updated to restify 3.0.3
    * Updated to mocha 2.2.5
    * Updated to should 7.0.1
    * Updated to supertest 1.0.1
    * Updated to istanbul 0.3.16