### PR TITLE
Adds several ways to populate referenced models in responses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,5 +265,27 @@ var users = restifyMongoose(User, {outputFormat: 'json-api', modelName: 'admins'
 users.serve('/users', restifyServer);
 ```
 
+## Populating referenced documents
+
+The returned results can use mongoose's "populate" query modifier to populated referenced documents within models.
+
+Referenced documents can be populated in three ways:
+
+### query parameter
+Adding `populate=[referenced_field]` to the query string will populate the referenced_field, if it exists.
+
+### Resource option
+```javascript
+// e.g.
+var notes = restifyMongoose(Note, {populate: 'author'});
+```
+
+### query / detail method options
+```javascript
+// e.g.
+server.get('/notes', notes.query({populate: 'author'}))
+server.get('/notes/:id', notes.detail({populate: 'author,contributors'}))
+```
+
 # Contribute
 Contribution welcome! Read the [contribution guideline](contributing.md) first.

--- a/README.md
+++ b/README.md
@@ -271,20 +271,27 @@ The returned results can use mongoose's "populate" query modifier to populated r
 
 Referenced documents can be populated in three ways:
 
-### query parameter
-Adding `populate=[referenced_field]` to the query string will populate the referenced_field, if it exists.
+#### query parameter
+Adding `populate=[referenced_field]` to the query string will populate the `referenced_field`, if it exists.
 
-### Resource option
+#### Resource option
 ```javascript
 // e.g.
 var notes = restifyMongoose(Note, {populate: 'author'});
 ```
 
-### query / detail method options
+#### query / detail method options
 ```javascript
 // e.g.
 server.get('/notes', notes.query({populate: 'author'}))
-server.get('/notes/:id', notes.detail({populate: 'author,contributors'}))
+server.get('/notes/:id', notes.detail({populate: 'author'}))
+```
+
+### Populating multiple fields
+Multipe referenced documents can be populated by using a comma-delimited list of the desired fields in any of the three methods above.
+```javascript
+// e.g.
+var notes = restifyMongoose(Note, {populate: 'author,contributors'});
 ```
 
 # Contribute

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ server.get('/notes/:id', notes.detail({populate: 'author'}))
 ```
 
 ### Populating multiple fields
-Multipe referenced documents can be populated by using a comma-delimited list of the desired fields in any of the three methods above.
+Multiple referenced documents can be populated by using a comma-delimited list of the desired fields in any of the three methods above.
 ```javascript
 // e.g.
 var notes = restifyMongoose(Note, {populate: 'author,contributors'});

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ var buildProjection = function (req, projection) {
 };
 
 var parsePopulateParam = function(populate) {
-  return populate.replace(',', ' ');
+  return populate.replace(/,/g, ' ');
 };
 
 var applyPageLinks = function (req, res, page, pageSize, baseUrl) {
@@ -218,10 +218,12 @@ Resource.prototype.query = function (options) {
   options.projection = options.projection || this.options.listProjection;
   options.outputFormat = options.outputFormat || this.options.outputFormat;
   options.modelName = options.modelName || this.options.modelName;
+  options.populate = options.populate || this.options.populate;
 
   return function (req, res, next) {
     var query = self.Model.find({});
     var countQuery = self.Model.find({});
+    var populate = req.query.populate || options.populate;
 
     if (req.query.q) {
       try {
@@ -241,8 +243,8 @@ Resource.prototype.query = function (options) {
       query = query.select(req.query.select);
     }
 
-    if (req.query.populate) {
-      query = query.populate(parsePopulateParam(req.query.populate));
+    if (populate) {
+      query = query.populate(parsePopulateParam(populate));
     }
 
     if (self.options.filter) {
@@ -277,14 +279,17 @@ Resource.prototype.detail = function (options) {
   options.projection = options.projection || this.options.detailProjection;
   options.outputFormat = options.outputFormat || this.options.outputFormat;
   options.modelName = options.modelName || this.options.modelName;
+  options.populate = options.populate || this.options.populate;
+
   return function (req, res, next) {
     var find = {};
     find[self.options.queryString] = req.params.id;
 
     var query = self.Model.findOne(find);
 
-    if (req.query.populate) {
-      query = query.populate(parsePopulateParam(req.query.populate));
+    var populate = req.query.populate || options.populate;
+    if (populate) {
+      query = query.populate(parsePopulateParam(populate));
     }
 
     if (self.options.filter) {

--- a/index.js
+++ b/index.js
@@ -138,6 +138,10 @@ var buildProjection = function (req, projection) {
   };
 };
 
+var parsePopulateParam = function(populate) {
+  return populate.replace(',', ' ');
+};
+
 var applyPageLinks = function (req, res, page, pageSize, baseUrl) {
   function makeLink(page, rel) {
     var path = url.parse(req.url, true);
@@ -237,10 +241,15 @@ Resource.prototype.query = function (options) {
       query = query.select(req.query.select);
     }
 
+    if (req.query.populate) {
+      query = query.populate(parsePopulateParam(req.query.populate));
+    }
+
     if (self.options.filter) {
       query = query.where(self.options.filter(req, res));
       countQuery = countQuery.where(self.options.filter(req, res));
     }
+
 
     var page = Number(req.query.p) >= 0 ? Number(req.query.p) : 0;
 
@@ -273,6 +282,10 @@ Resource.prototype.detail = function (options) {
     find[self.options.queryString] = req.params.id;
 
     var query = self.Model.findOne(find);
+
+    if (req.query.populate) {
+      query = query.populate(parsePopulateParam(req.query.populate));
+    }
 
     if (self.options.filter) {
       query = query.where(self.options.filter(req, res));

--- a/test/author.js
+++ b/test/author.js
@@ -1,0 +1,9 @@
+var mongoose = require('mongoose');
+
+var AuthorSchema = new mongoose.Schema({
+  name : { type : String, required : true }
+});
+
+var Author = mongoose.model('author', AuthorSchema);
+
+module.exports = Author;

--- a/test/note.js
+++ b/test/note.js
@@ -8,7 +8,11 @@ var NoteSchema = new mongoose.Schema({
   author : {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'author'
-  }
+  },
+  contributors : [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'author'
+  }]
 });
 
 var Note = mongoose.model('notes', NoteSchema);

--- a/test/note.js
+++ b/test/note.js
@@ -4,7 +4,11 @@ var NoteSchema = new mongoose.Schema({
   title : { type : String, required : true },
   date : { type : Date, required : true },
   tags : [String],
-  content : { type: String }
+  content : { type: String },
+  author : {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'author'
+  }
 });
 
 var Note = mongoose.model('notes', NoteSchema);


### PR DESCRIPTION
Implements mongoose's "populate" query modifier. Referenced documents can be populated in three ways:

### query parameter
Adding `populate=[referenced_field]` to the query string will populate the referenced_field, if it exists.

### Resource option
```javascript
// e.g.
var notes = restifyMongoose(Note, {populate: 'author'});
```

### query / detail method options
```javascript
// e.g.
server.get('/notes', notes.query({populate: 'author'}))
server.get('/notes/:id', notes.detail({populate: 'author,contributors'}))
```