### PR TITLE
Select fields in the options object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,11 +188,26 @@ To sort a notes resource by title descending append the __sort__ query parameter
 ## Select Fields
 To restrict selected columns you can pass a query string parameter __select__.
 
-Select fields are passed directly to [mongoose select query function](http://mongoosejs.com/docs/api.html#query_Query-select).
+Select fields can be separated by comma or space. They will be passed to [mongoose select query function](http://mongoosejs.com/docs/api.html#query_Query-select).
 
-To select only date the field of a notes resource append the __select__ query parameter to the URL:
+To select only title and date the fields of a notes resource append the __select__ query parameter to the URL:
 
-    http://localhost:3000/notes?select=date
+    http://localhost:3000/notes?select=title,date
+
+You can also define select fields in the options object. This will make the the __select__ query parameter be ignored.
+
+Using in the constructor:
+```javascript
+var notes = restifyMongoose(Note, {select: 'title'});
+notes.serve('/notes', restifyServer);
+```
+
+Using for query or detail methods:
+```javascript
+var notes = restifyMongoose(Note);
+note.detail({select: 'title,date,tags'});
+note.query({select: 'title date'});
+```
 
 ## Filter
 Results can be filtered with a function, which is set in the options object of the constructor or on the `query` and `detail` function.

--- a/test/restify-mongoose.js
+++ b/test/restify-mongoose.js
@@ -178,6 +178,22 @@ describe('restify-mongoose', function () {
         .end(done);
     });
 
+    it('should select fields of notes according to options', function (done) {
+      request(server({select: "title"}))
+        .get('/notes?select=date')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .expect(function (res) {
+          res.body[0].should.have.property('title');
+          res.body[0].should.not.have.property('date');
+          res.body[1].should.have.property('title');
+          res.body[1].should.not.have.property('date');
+          res.body[2].should.have.property('title');
+          res.body[2].should.not.have.property('date');
+        })
+        .end(done);
+    });
+
     it('should emit event after querying notes', function (done) {
       var svr = server();
 
@@ -534,6 +550,31 @@ describe('restify-mongoose', function () {
           .expect(200)
           .expect(function (res) {
             res.body.title.should.equal('detailtitle');
+          })
+          .end(done);
+      });
+    });
+
+    it('should select detail note according to options', function (done) {
+      Note.create({
+        title: 'detailtitleselect',
+        date: new Date(),
+        tags: ['a', 'b', 'c'],
+        content: 'Content Select'
+      }, function (err, note) {
+        if (err) {
+          throw err;
+        }
+
+        request(server({select: "title content"}))
+          .get('/notes/' + note.id)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .expect(function (res) {
+            res.body.title.should.equal('detailtitleselect');
+            res.body.content.should.equal('Content Select');
+            res.body.should.not.have.property('date');
+            res.body.should.not.have.property('tags');
           })
           .end(done);
       });


### PR DESCRIPTION
Hi! I implemented a way to configure the select fields in the code, using the option object. 
If it is configured in the code, the select parameter of the request will take no effect.
This is useful when one have to restrict witch fields to show, but without the overhead of the projection function.
We can discuss a little more if you want.