### PR TITLE
Set null for Error-first callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const emitEvent = function (self, event) {
     self.emit(event, model);
 
     if (cb) {
-      cb(undefined, model);
+      cb(null, model);
     }
   };
 };
@@ -43,7 +43,7 @@ const sendData = function (res, format, modelName, status) {
     else {
       res.send(status, model);
     }
-    cb(undefined, model);
+    cb(null, model);
   };
 };
 


### PR DESCRIPTION
Reference: [https://nodejs.org/api/errors.html#errors_error_first_callbacks](https://nodejs.org/api/errors.html#errors_error_first_callbacks)

>  If no error was raised, the first argument will be passed as null.